### PR TITLE
Split build and publish to separate step actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,34 @@ jobs:
         - name: Validate gradle wrapper
           uses: gradle/wrapper-validation-action@v1
 
-        - name: Build, test, publishToMavenLocal, publishToSonatype and closeSonatypeStagingRepository
+        - name: Build and Test
+          uses: gradle/gradle-build-action@v2
+          with:
+              arguments: |
+                  --info
+                  --console=plain
+                  --no-daemon
+                  build
+
+        - name: publishToMavenLocal, publishToSonatype and closeSonatypeStagingRepository
+          if: success()
+          uses: gradle/gradle-build-action@v2
+          with:
+              arguments: |
+                  --info
+                  --console=plain
+                  --no-daemon
+                  publishToMavenLocal
+                  -Pversion=${{ github.event.release.tag_name }}
+                  -PsignPublication=true
+
+        - name: Display tree of mavenLocal
+          if: success()
+          run: tree ~/.m2/repository/io/github/jrestclients
+
+
+        - name: publishToSonatype and closeSonatypeStagingRepository
+          if: success()
           uses: gradle/gradle-build-action@v2
           env:
               ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
@@ -62,14 +89,9 @@ jobs:
                   --info
                   --console=plain
                   --no-daemon
-                  build
-                  publishToMavenLocal
                   publishToSonatype
                   closeSonatypeStagingRepository
                   -Pversion=${{ github.event.release.tag_name }}
                   -PsignPublication=true
-
-        - name: Display tree of mavenLocal
-          run: tree ~/.m2/repository/io/github/jrestclients
 
         # Additional steps are needed to update the documentation

--- a/.github/workflows/run-test-on-pull-request.yml
+++ b/.github/workflows/run-test-on-pull-request.yml
@@ -132,6 +132,15 @@ jobs:
           with:
               arguments: |
                   build
+                  --console=plain
+                  --no-daemon
+
+        - name: Publish to MavenLocal
+          # Using --scan publishes the test results to the gradle server
+          # When using spock test, the gradle server shows the details of the failures, eliminating the need to publish JUnit test reports
+          uses: gradle/gradle-build-action@v2
+          with:
+              arguments: |
                   publishToMavenLocal
                   --console=plain
                   --no-daemon

--- a/.github/workflows/run-test-on-pull-request.yml
+++ b/.github/workflows/run-test-on-pull-request.yml
@@ -126,6 +126,7 @@ jobs:
           uses: gradle/wrapper-validation-action@v1
 
         - name: Run tests
+          if: success()
           # Using --scan publishes the test results to the gradle server
           # When using spock test, the gradle server shows the details of the failures, eliminating the need to publish JUnit test reports
           uses: gradle/gradle-build-action@v2
@@ -136,6 +137,7 @@ jobs:
                   --no-daemon
 
         - name: Publish to MavenLocal
+          if: success()
           # Using --scan publishes the test results to the gradle server
           # When using spock test, the gradle server shows the details of the failures, eliminating the need to publish JUnit test reports
           uses: gradle/gradle-build-action@v2


### PR DESCRIPTION
Hope this solves the publishing which published with only metadata artifacts.